### PR TITLE
DLS-10699: Fix for the deprecated HttpReadsLegacyJson

### DIFF
--- a/app/uk/gov/hmrc/individualdetailsdesstub/connector/ApiPlatformTestUserConnector.scala
+++ b/app/uk/gov/hmrc/individualdetailsdesstub/connector/ApiPlatformTestUserConnector.scala
@@ -18,7 +18,8 @@ package uk.gov.hmrc.individualdetailsdesstub.connector
 
 import com.google.inject.{Inject, Singleton}
 import uk.gov.hmrc.domain.{Nino, SaUtr}
-import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, NotFoundException}
+import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, UpstreamErrorResponse}
 import uk.gov.hmrc.individualdetailsdesstub.domain.{NinoNoSuffix, TestIndividual, TestUserNotFoundException}
 import uk.gov.hmrc.individualdetailsdesstub.http.HttpClientOps
 import uk.gov.hmrc.individualdetailsdesstub.util.JsonFormatters.formatTestUser
@@ -42,6 +43,6 @@ class ApiPlatformTestUserConnector @Inject()(servicesConfig: ServicesConfig, htt
 
   private def getTestIndividual(url: String)(implicit hc: HeaderCarrier) =
     http.GET[TestIndividual](url) recover {
-      case _: NotFoundException => throw new TestUserNotFoundException
+      case ex: UpstreamErrorResponse if ex.statusCode == 404 => throw new TestUserNotFoundException
     }
 }

--- a/test/unit/uk/gov/hmrc/individualdetailsdesstub/connector/ApiPlatformTestUserConnectorSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualdetailsdesstub/connector/ApiPlatformTestUserConnectorSpec.scala
@@ -19,7 +19,6 @@ package unit.uk.gov.hmrc.individualdetailsdesstub.connector
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
-import java.time.LocalDate
 import org.scalatest.BeforeAndAfterEach
 import play.api.test.Helpers._
 import uk.gov.hmrc.domain.{Nino, SaUtr}
@@ -30,6 +29,7 @@ import uk.gov.hmrc.individualdetailsdesstub.http.HttpClientOps
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import unit.uk.gov.hmrc.individualdetailsdesstub.util.utils.SpecBase
 
+import java.time.LocalDate
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
 class ApiPlatformTestUserConnectorSpec extends SpecBase with BeforeAndAfterEach {


### PR DESCRIPTION
- added import uk.gov.hmrc.http.HttpReads.Implicits._  to tackle  `method readFromJson in trait HttpReadsLegacyJson is deprecated` warning

- After that fixed 3 failing tests 
` Expected exception uk.gov.hmrc.individualdetailsdesstub.domain.TestUserNotFoundException to be thrown, but uk.gov.hmrc.http.Upstream4xxResponse was thrown` that resulted from adding the import by adding handling for Upstream4xxResponse/UpstreamErrorResponse exception

